### PR TITLE
Remove unnecessary version pegging

### DIFF
--- a/redshift-connector.gemspec
+++ b/redshift-connector.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.1.0'
-  s.add_dependency 'activerecord', '< 5'
-  s.add_dependency 'activerecord4-redshift-adapter'
+  s.add_dependency 'activerecord'
+  s.add_dependency 'activerecord-redshift'
   s.add_dependency 'redshift-connector-data_file', '~> 1.0.0'
-  s.add_dependency 'pg', '~> 0.18.0'
+  s.add_dependency 'pg'
   s.add_dependency 'activerecord-import'
   s.add_dependency 'aws-sdk', '~> 2.0'
   s.add_development_dependency 'test-unit'

--- a/redshift-connector.gemspec
+++ b/redshift-connector.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord'
   s.add_dependency 'activerecord-redshift'
   s.add_dependency 'redshift-connector-data_file', '~> 1.0.0'
-  s.add_dependency 'pg'
+  s.add_dependency 'pg', '~> 0.18'
   s.add_dependency 'activerecord-import'
   s.add_dependency 'aws-sdk', '~> 2.0'
   s.add_development_dependency 'test-unit'


### PR DESCRIPTION
This PR removes useless version pegging to fit both Rails 4.x and Rails 5.x in single gem version.
In the past and now, users need to switch v5.x and v4.x series properly by Rails version but this change make it unnecessary.