### PR TITLE
Refactor codes around transporting

### DIFF
--- a/lib/redshift-connector/importer.rb
+++ b/lib/redshift-connector/importer.rb
@@ -28,6 +28,20 @@ module RedshiftConnector
         filter: filter,
         logger: logger
       )
+      transport_delta_from_bundle(
+        bundle: bundle,
+        table: table, columns: columns,
+        delete_cond: delete_cond, upsert_columns: upsert_columns,
+        logger: logger, quiet: quiet
+      )
+    end
+
+    def Importer.transport_delta_from_bundle(
+      bundle:,
+      table:, columns:,
+      delete_cond: nil, upsert_columns: nil,
+      logger: RedshiftConnector.logger, quiet: false
+    )
       if delete_cond and upsert_columns
         raise ArgumentError, "delete_cond and upsert_columns are exclusive"
       end
@@ -68,6 +82,20 @@ module RedshiftConnector
         filter: filter,
         logger: logger
       )
+      transport_all_from_bundle(
+        strategy: strategy,
+        bundle: bundle,
+        table: table, columns: columns,
+        logger: logger, quiet: quiet
+      )
+    end
+
+    def Importer.transport_all_from_bundle(
+      strategy: 'rename',
+      bundle:,
+      table:, columns:,
+      logger: RedshiftConnector.logger, quiet: false
+    )
       importer = get_rebuild_class(strategy).new(
         dao: table.classify.constantize,
         bundle: bundle,

--- a/redshift-connector.gemspec
+++ b/redshift-connector.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
   s.add_dependency 'activerecord'
   s.add_dependency 'activerecord-redshift'
-  s.add_dependency 'redshift-connector-data_file', '~> 1.0.0'
+  s.add_dependency 'redshift-connector-data_file', '~> 1.1.0'
   s.add_dependency 'pg', '~> 0.18'
   s.add_dependency 'activerecord-import'
   s.add_dependency 'aws-sdk', '~> 2.0'


### PR DESCRIPTION
There had been duplicated codes in both `Connector.transport_*` and `Importer. transport_*_from_s3`.
Duplicated codes were factored out as `Importer.transport_*_from_bundle` and they use them.

In addition, common methods in S3DataFileBundle were separated to AbstractDataFileBundle in other gem. This change let`Importer` receive not only `S3DataFileBundle` but `UrlDataFileBundle` or other DataFileBundle.