### PR TITLE
Set nil to table key [transport_all]

### DIFF
--- a/lib/redshift_connector/connector.rb
+++ b/lib/redshift_connector/connector.rb
@@ -115,7 +115,7 @@ module RedshiftConnector
     def Connector.transport_all(
         strategy: 'rename',
         schema:,
-        table:,
+        table: nil,
         src_table: table,
         dest_table: table,
         columns:,


### PR DESCRIPTION
This patch fixes the following error.

batch definition:
```ruby
RedshiftConnector.transport_all(
  strategy: 'rename',
  schema: 'your_schema',
  # table: 'table_name'
  src_table: 'source_table_name',
  dest_table: 'dest_table_name',
)
```
output:
```shell
...
redshift-connector-7.2.1/lib/redshift_connector.rb:21:in `transport_all'
redshift_connector/connector.rb:115:in `transport_all': missing keyword: table (ArgumentError)
```