### PR TITLE
new: Allows pg > 0.18 to support Rails 5

### DIFF
--- a/redshift_connector.gemspec
+++ b/redshift_connector.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
   s.add_dependency 'activerecord'
   s.add_dependency 'activerecord-redshift'
-  s.add_dependency 'pg', '~> 0.18.0'
+  s.add_dependency 'pg', '>= 0.18.0'
   s.add_dependency 'activerecord-import'
   s.add_dependency 'redshift_csv_file', '~> 1.0'
   s.add_dependency 'aws-sdk-s3', '~> 1.0'


### PR DESCRIPTION
I loosen pg version restriction from "~> 0.18.0" to ">= 0.18.0" to support Rails 5.

Note that Redshift is PostgreSQL 8 compatible and pg >0.18 does not support PostgreSQL 8.  Now you can use any version of pg and most version of pg works with Redshift, but you must take a risk.