### PR TITLE
Add enable cast option for redshift_connector-queuery

### DIFF
--- a/lib/redshift_connector/data_file_bundle_reader.rb
+++ b/lib/redshift_connector/data_file_bundle_reader.rb
@@ -22,7 +22,7 @@ module RedshiftConnector
 
     def each_row(&block)
       each_object do |obj|
-        if @bundle.has_manifest?
+        if @bundle.respond_to?(:has_manifest?) && @bundle.has_manifest?
           obj.each_row do |row|
             yield type_cast(row)
           end

--- a/lib/redshift_connector/exporter_builder.rb
+++ b/lib/redshift_connector/exporter_builder.rb
@@ -23,6 +23,7 @@ module RedshiftConnector
         table:,
         bucket: nil,
         query:,
+        query_params: [],
         txn_id: "#{Time.now.strftime('%Y%m%d_%H%M%S')}_#{$$}",
         enable_sort: false,
         enable_cast: false,
@@ -40,6 +41,7 @@ module RedshiftConnector
       @exporter_class.new(
         ds: @ds,
         query: ArbitraryQuery.new(query),
+        query_params: query_params,
         bundle_params: bundle_params,
         enable_sort: enable_sort,
         enable_cast: enable_cast,

--- a/lib/redshift_connector/exporter_builder.rb
+++ b/lib/redshift_connector/exporter_builder.rb
@@ -25,6 +25,7 @@ module RedshiftConnector
         query:,
         txn_id: "#{Time.now.strftime('%Y%m%d_%H%M%S')}_#{$$}",
         enable_sort: false,
+        enable_cast: false,
         logger: RedshiftConnector.logger,
         quiet: false
     )
@@ -41,6 +42,7 @@ module RedshiftConnector
         query: ArbitraryQuery.new(query),
         bundle_params: bundle_params,
         enable_sort: enable_sort,
+        enable_cast: enable_cast,
         logger: logger
       )
     end

--- a/lib/redshift_connector/redshift_data_type.rb
+++ b/lib/redshift_connector/redshift_data_type.rb
@@ -1,0 +1,27 @@
+
+module RedshiftConnector
+  module RedshiftDataType
+    def self.type_cast(row, manifest_file)
+      row.zip(manifest_file.column_types).map do |value, type|
+        next nil if (value == '' and type != 'character varing') # null becomes '' on unload
+
+        case type
+        when 'smallint', 'integer', 'bigint'
+          value.to_i
+        when 'numeric', 'double precision'
+          value.to_f
+        when 'character', 'character varying'
+          value
+        when 'timestamp without time zone', 'timestamp with time zone'
+          Time.parse(value)
+        when 'date'
+          Date.parse(value)
+        when 'boolean'
+          value == 'true' ? true : false
+        else
+          raise "not support data type: #{type}"
+        end
+      end
+    end
+  end
+end

--- a/test/test_s3_import.rb
+++ b/test/test_s3_import.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 require 'test/unit'
-require 'redshift-connector'
+require 'redshift_connector'
 
 class TestS3Import < Test::Unit::TestCase
   def test_import_delta_tsv


### PR DESCRIPTION
関連 https://github.com/bricolages/queuery_client/pull/7 , https://github.com/bricolages/redshift_connector-queuery/pull/2

RedshiftのUnloadで使えるMANIFESTオプションを有効にできるようにします。
https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_UNLOAD.html

https://github.com/bricolages/redshift_connector-queuery/pull/2 のPRの修正でqueuery_clientの内容に型キャスト用のパラメータを渡せるようになりましたが、実際に型をキャストするのは `each_row` の部分で行うためこちらにも修正が必要となりました。QueueryClient側にも似たような修正を入れたのでできればまとめたかったのですが、 each_row の実装が別れていたためこうしました。

`@bundle` をみて、 `QueueryClient` にある manifest_file に対応している bundle であったら型キャストをするようになります。こちらの修正を行ったコードを読み込んだ上で redshift_connector-queuery#2 の挙動確認を行いました。

テストの際には QueueryDataSource以外の、ARを元にしたDataSourceを使って確認しました。

```ruby
  class RedshiftBase < ActiveRecord::Base
    self.abstract_class = true
    establish_connection :"redshift"
  end

  Exporter.default_data_source = ActiveRecordDataSource.new(RedshiftBase)
```