### PR TITLE
Add type cast option to transport_delta/all methods

### DIFF
--- a/lib/redshift_connector/active_record_exporter.rb
+++ b/lib/redshift_connector/active_record_exporter.rb
@@ -4,7 +4,8 @@ require 'redshift_connector/logger'
 
 module RedshiftConnector
   class ActiveRecordExporter
-    def initialize(ds:, query:, bundle_params:, enable_sort: false, logger: RedshiftConnector.logger)
+    def initialize(ds:, query:, bundle_params:, enable_sort: false, enable_cast: false, logger: RedshiftConnector.logger)
+      raise ArgumentError, "ActiveRecordExporter does not support type cast" if enable_cast
       @ds = ds
       @query = query
       @bundle_params = bundle_params

--- a/lib/redshift_connector/connector.rb
+++ b/lib/redshift_connector/connector.rb
@@ -49,13 +49,17 @@ module RedshiftConnector
         upsert_columns: nil,
         bucket: nil,
         txn_id: nil,
-        filter:,
+        filter: nil,
+        enable_cast: false,
         logger: RedshiftConnector.logger,
         quiet: false
     )
       unless src_table and dest_table
         raise ArgumentError, "missing :table, :src_table or :dest_table"
       end
+      raise ArgumentError, "filter and enable_cast are exclusive" if filter and enable_cast
+      raise ArgumentError, "either filter or enable_cast is required" unless filter or enable_cast
+
       logger = NullLogger.new if quiet
       bundle_params = DataFileBundleParams.new(
         bucket: bucket,
@@ -70,6 +74,7 @@ module RedshiftConnector
         table: src_table,
         columns: columns,
         condition: condition,
+        enable_cast: enable_cast,
         logger: logger
       )
       importer = Importer.for_delta_upsert(
@@ -119,10 +124,14 @@ module RedshiftConnector
         columns:,
         bucket: nil,
         txn_id: nil,
-        filter:,
+        filter: nil,
+        enable_cast: false,
         logger: RedshiftConnector.logger,
         quiet: false
     )
+    raise ArgumentError, "filter and enable_cast are exclusive" if filter and enable_cast
+    raise ArgumentError, "either filter or enable_cast is required" unless filter or enable_cast
+
       logger = NullLogger.new if quiet
       bundle_params = DataFileBundleParams.new(
         bucket: bucket,
@@ -136,6 +145,7 @@ module RedshiftConnector
         schema: schema,
         table: src_table,
         columns: columns,
+        enable_cast: enable_cast,
         logger: logger
       )
       importer = Importer.for_rebuild(

--- a/lib/redshift_connector/exporter_builder.rb
+++ b/lib/redshift_connector/exporter_builder.rb
@@ -8,14 +8,14 @@ module RedshiftConnector
       @exporter_class = exporter_class
     end
 
-    def build_for_table_delta(schema:, table:, condition:, columns:, bundle_params:, logger: RedshiftConnector.logger)
+    def build_for_table_delta(schema:, table:, condition:, columns:, enable_cast:, bundle_params:, logger: RedshiftConnector.logger)
       query = DeltaQuery.new(schema: schema, table: table, columns: columns, condition: condition)
-      @exporter_class.new(ds: @ds, query: query, bundle_params: bundle_params, logger: logger)
+      @exporter_class.new(ds: @ds, query: query, bundle_params: bundle_params, enable_cast: enable_cast, logger: logger)
     end
 
-    def build_for_table(schema:, table:, columns:, bundle_params:, logger: RedshiftConnector.logger)
+    def build_for_table(schema:, table:, columns:, enable_cast:, bundle_params:, logger: RedshiftConnector.logger)
       query = SelectAllQuery.new(schema: schema, table: table, columns: columns)
-      @exporter_class.new(ds: @ds, query: query, bundle_params: bundle_params, logger: logger)
+      @exporter_class.new(ds: @ds, query: query, bundle_params: bundle_params, enable_cast: enable_cast, logger: logger)
     end
 
     def build_for_query(

--- a/test/test_type_cast_option.rb
+++ b/test/test_type_cast_option.rb
@@ -1,0 +1,136 @@
+require_relative 'helper'
+require 'test/unit'
+
+class TestTypeCastOption < Test::Unit::TestCase
+  def test_pass_cast_option_delta
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_delta(
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+
+      txn_id: data_date,
+      condition: %Q(data_date = date '#{data_date}'),
+      delete_cond: %Q(data_date = date '#{data_date}'),
+
+      columns: %w[id data_date item_id pv uu],
+      filter: -> (id, data_date, item_id, pv, uu) {
+        [id.to_i, data_date, item_id.to_i, pv.to_i, uu.to_i]
+      },
+      enable_cast: false
+    )
+    job.execute
+  end
+
+  def test_not_support_cast_delta
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_delta(
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+
+        txn_id: data_date,
+        condition: %Q(data_date = date '#{data_date}'),
+        delete_cond: %Q(data_date = date '#{data_date}'),
+
+        columns: %w[id data_date item_id pv uu],
+        enable_cast: true
+      )
+    }
+  end
+
+  def test_dup_options_delta
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_delta(
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+
+        txn_id: data_date,
+        condition: %Q(data_date = date '#{data_date}'),
+        delete_cond: %Q(data_date = date '#{data_date}'),
+
+        columns: %w[id data_date item_id pv uu],
+        filter: -> (id, data_date, item_id, pv, uu) {
+          [id.to_i, data_date, item_id.to_i, pv.to_i, uu.to_i]
+        },
+        enable_cast: true
+      )
+    }
+  end
+
+  def test_non_option_delta
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_delta(
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+
+        txn_id: data_date,
+        condition: %Q(data_date = date '#{data_date}'),
+        delete_cond: %Q(data_date = date '#{data_date}'),
+
+        columns: %w[id data_date item_id pv uu],
+      )
+    }
+  end
+
+  def test_pass_cast_option_all
+    data_date = '2016-11-03'
+    job = RedshiftConnector.transport_all(
+      strategy: 'truncate',
+      schema: $TEST_SCHEMA,
+      table: 'item_pvs',
+      txn_id: data_date,
+      columns: %w[id data_date item_id pv uu],
+      filter: -> (id, data_date, item_id, pv, uu) {
+        [id.to_i, data_date, item_id.to_i, pv.to_i, uu.to_i]
+      },
+      enable_cast: false
+    )
+    job.execute
+  end
+
+  def test_not_support_cast_all
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_all(
+        strategy: 'truncate',
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+        txn_id: data_date,
+        columns: %w[id data_date item_id pv uu],
+        enable_cast: true
+      )
+    }
+  end
+
+  def test_dup_options_all
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_all(
+        strategy: 'truncate',
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+        txn_id: data_date,
+        columns: %w[id data_date item_id pv uu],
+        filter: -> (id, data_date, item_id, pv, uu) {
+          [id.to_i, data_date, item_id.to_i, pv.to_i, uu.to_i]
+        },
+        enable_cast: true
+      )
+    }
+  end
+
+  def test_non_option_all
+    data_date = '2016-11-03'
+    assert_raise(ArgumentError) {
+      job = RedshiftConnector.transport_all(
+        strategy: 'truncate',
+        schema: $TEST_SCHEMA,
+        table: 'item_pvs',
+        txn_id: data_date,
+        columns: %w[id data_date item_id pv uu],
+      )
+    }
+  end
+end


### PR DESCRIPTION
https://github.com/bricolages/redshift_connector/pull/21 で追加した型キャストを `transport_delta` と `transport_all` でも扱えるようにします。
同時に `filter:` 引数は必須ではなくなり、 `enable_cast:` 引数と**どちらか片方だけ**つけるキーワード引数となります。両方あっても両方無くても例外があがります。
`enable_cast:` はデフォルトでは`false`になっており、後方互換性を保っています。

ただし、このgem単体では `Exporter.default_data_source` を型キャストに対応したものにできないため、 `transport_delta`  で `enable_cast` を `true` にできるのは redshift_connector-queuery を使って`transport_delta` をしたときだけです。（allについても同様）
