### PR TITLE
Remove dependency on activerecord-redshift to upgrade activerecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 gemspec
 
-# We need explicit version specification (4 or 5) here,
-# to resolve version dependencies correctly.
-gem 'activerecord', '~> 5.0'
+gem 'activerecord'
 gem 'mysql2'

--- a/redshift_connector.gemspec
+++ b/redshift_connector.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.0'
   s.add_dependency 'activerecord'
-  s.add_dependency 'activerecord-redshift'
   s.add_dependency 'pg', '>= 0.18.0'
   s.add_dependency 'activerecord-import'
   s.add_dependency 'redshift_csv_file', '~> 1.0'

--- a/test/config.rb.example
+++ b/test/config.rb.example
@@ -2,7 +2,7 @@ module RedshiftConnector
   # For test only
   $TEST_SCHEMA = 'test'
 
-  Exporter.default_data_source = Redshift
+  Exporter.default_data_source = RedshiftConnector::ActiveRecordDataSource.new(Postgresql)
 
   S3Bucket.add(
     'ENTRY_NAME',

--- a/test/config.rb.example
+++ b/test/config.rb.example
@@ -2,7 +2,7 @@ module RedshiftConnector
   # For test only
   $TEST_SCHEMA = 'test'
 
-  Exporter.default_data_source = RedshiftConnector::ActiveRecordDataSource.new(Postgresql)
+  Exporter.default_data_source = RedshiftConnector::ActiveRecordDataSource.new(Redshift)
 
   S3Bucket.add(
     'ENTRY_NAME',

--- a/test/database.yml.example
+++ b/test/database.yml.example
@@ -5,7 +5,7 @@ mysql:
   database: test
   encoding: utf8
 
-postgresql:
+redshift:
   adapter: postgresql
   host: HOST_NAME
   port: 5439

--- a/test/database.yml.example
+++ b/test/database.yml.example
@@ -5,8 +5,8 @@ mysql:
   database: test
   encoding: utf8
 
-redshift:
-  adapter: redshift
+postgresql:
+  adapter: postgresql
   host: HOST_NAME
   port: 5439
   database: DATABASE_NAME

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,8 +13,8 @@ end
 class ItemPv < BaseConn
   connection
 end
-class Postgresql < ActiveRecord::Base
-  establish_connection :postgresql
+class Redshift < ActiveRecord::Base
+  establish_connection :redshift
 end
 
 require 'redshift_connector'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,8 +13,8 @@ end
 class ItemPv < BaseConn
   connection
 end
-class Redshift < ActiveRecord::Base
-  establish_connection :redshift
+class Postgresql < ActiveRecord::Base
+  establish_connection :postgresql
 end
 
 require 'redshift_connector'


### PR DESCRIPTION
Rails 7 以降でこの gem を利用できるようにするために、activerecord-redshfit への依存を取り除きます。

activerecord-redshift への依存を削除した上で、https://github.com/bricolages/queuery_client 、 https://github.com/bricolages/redshift_connector-queuery と合わせて手元で動作することは確認しました。

master (ないしは任意のブランチ) にマージした上で、commit hash を指定して自分の環境にインストールすることで、Rails 7 以降のアプリケーションでこの gem を使いたいです。

